### PR TITLE
Fix segmentation fault in hammer

### DIFF
--- a/dthammer.c
+++ b/dthammer.c
@@ -968,7 +968,12 @@ hammer_doio(dinfo_t *dip)
 	    case OWRITEFILE: {
 		if ( (f = getrndfile(dip)) != NULL) {
 		    status = writefile(dip, f);
-		    if (status == SUCCESS) hmrp->num_iterations++;
+		    if (status == SUCCESS) {
+			hmrp->num_iterations++;
+		    }
+		    else {
+			f = NULL;
+		    }
 		}
 		break;
 	    }
@@ -2060,6 +2065,7 @@ freefile(dinfo_t *dip, hammer_file_t *file)
 	return(FAILURE);
     }
     freestr(file->path);
+    freestr(file->colon);
     freestr(file->fpath);
     memset(file, 0xdd, sizeof(*file));
     free(file);


### PR DESCRIPTION
If an OWRITE is attempted but fails due to HAMMER_DISK_FULL and the `hammer_file_t` is `freefile()`'d, further attempts to use the `hammer_file_t` structure in `hammer_doio` cause a seg fault.

This change fixes the issue by setting the hammer_file_t pointer to NULL so further nullity checks correctly get the state of the file data structure.

An alternate fix is for the `freestr()` at [ln 1013](https://github.com/RobinTMiller/dt/blob/master/dthammer.c#L1013) (and its if statement) to be removed.
Or for freefile() to be able to NULL the pointer (e.g. pass double pointers all the way down to it so it can modify `f` in `hammer_doio`).